### PR TITLE
Refactor rss service

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Ruby 3.2.2
 
 ## Versions
 
-Current version: **5.1.0**
+Current version: **5.2.0**
 
 ## Changelog
 

--- a/app/services/games_fetcher_service.rb
+++ b/app/services/games_fetcher_service.rb
@@ -11,8 +11,8 @@ class GamesFetcherService
   class << self
     def fetch_games
       sources = {
-        RSS_URL => { :method => method(:process_rss_response), :service => :Rss},
-        HTML_URL => { :method => method(:process_html_response), :service => :Html}
+        HTML_URL => { :method => method(:process_html_response), :service => :Html },
+        RSS_URL => { :method => method(:process_rss_response), :service => :Rss }
       }
 
       sources.each do |url, processing_info|

--- a/app/services/printers/html_service.rb
+++ b/app/services/printers/html_service.rb
@@ -9,7 +9,6 @@ module Printers
              "#{Paint[game[:tv], :gray, :italic]}" +
              "#{SEPARATOR}" +
              "#{Paint[colorize_my_team(teams), :bold]} "+
-             # "#{SEPARATOR}" +
              "#{Paint[game[:competition], :cyan, :inverse]}\n"
     end
 

--- a/app/services/printers/rss_service.rb
+++ b/app/services/printers/rss_service.rb
@@ -3,18 +3,28 @@
 module Printers
   class RssService < ::PrintersManagerService
     def print_game(game)
-      game_details = game['title'].split(SEPARATOR)
-      return if game_details.size < 2
+      game_info = game['title']
+      return if game_info.size < 2
 
-      puts "THIS NEED TO BE REFACTORED"
-      exit
+      date, time, teams, tv_channel = parse_date_teams(game_info)
 
-      # TODO when the RSS Zapping of zerozero is back working I need to do some refactor for this to work
-      # game_information = "#{offset(game['pubDate'])} " +
-      #   "#{Paint[game_details.last, :white, :italic]}#{DETAIL_SEPARATOR}" +
-      #   "#{Paint[colorize_my_team(game_details.first), :bold]}\n"
-      #
-      # puts game_information
+      puts "#{offset(date, time)} " +
+             "#{Paint[tv_channel, :gray, :italic]}" +
+             "#{SEPARATOR}" +
+             "#{Paint[colorize_my_team(teams), :bold]}\n"
     end
+
+    private
+
+      def parse_date_teams(game_info)
+        match_data = game_info.match(/^(.*)\s+-\s+(\d{1,2}\/\d{1,2})\s(\d{1,2}:\d{1,2})\s-\s(.*)$/)
+
+        teams = match_data[1]
+        date = match_data[2]
+        time = match_data[3]
+        tv_channel = match_data[4]
+
+        [date, time, teams, tv_channel]
+      end
   end
 end

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,8 @@
 # Changelog
+## [5.2.0] - 2024/03/28
+### Changed
+*  Refactor RssService 
+
 ## [5.1.0] - 2024/03/28
 ### Added
 * Now with the competitions info

--- a/spec/services/printers/html_service_spec.rb
+++ b/spec/services/printers/html_service_spec.rb
@@ -1,4 +1,3 @@
-# spec/services/printers/html_service_spec.rb
 RSpec.describe Printers::HtmlService do
   let(:city_tz) { ActiveSupport::TimeZone["London"] }
   let(:game) { {info: '01/01 00:00  Team1 - Team2', tv: 'TV Channel'} }

--- a/spec/services/printers/rss_service_spec.rb
+++ b/spec/services/printers/rss_service_spec.rb
@@ -1,13 +1,31 @@
-# spec/services/printers/rss_service_spec.rb
 RSpec.describe Printers::RssService do
   let(:city_tz) { ActiveSupport::TimeZone["London"] }
-  let(:game) { {'title' => 'Some Game - Game Detail', 'pubDate' => '01 Apr 2023 15:10:10 GMT'} }
 
   subject(:service) { described_class.new([game], city_tz) }
 
   describe '#print_game' do
-    it 'prints the correct message' do
-      expect { service.print_game(game) }.to output("THIS NEED TO BE REFACTORED\n").to_stdout
+    context 'when the title has a proper format' do
+      let(:game) { {'title' => 'FC Genoa x Cagliari FC - 29/04 19:45 - SportTv3', 'pubDate' => '01 Apr 2023 15:10:10 GMT'} }
+
+      it 'prints the correct game info' do
+        expect { service.print_game(game) }.to output(/29\/04 19:45.*SportTv3.*FC Genoa x Cagliari FC/).to_stdout
+      end
+    end
+
+    context 'when the title has only one digit for date and time' do
+      let(:game) { {'title' => 'FC Genoa x Cagliari FC - 9/4 1:9 - SportTv3', 'pubDate' => '01 Apr 2023 15:10:10 GMT'} }
+
+      it 'prints the correct game info' do
+        expect { service.print_game(game) }.to output(/09\/04 01:09.*SportTv3.*FC Genoa x Cagliari FC/).to_stdout
+      end
+    end
+
+    context 'when the title is missing' do
+      let(:game) { {'title' => '', 'pubDate' => '01 Apr 2023 15:10:10 GMT'} }
+
+      it 'does not print anything' do
+        expect { service.print_game(game) }.not_to output.to_stdout
+      end
     end
   end
 end

--- a/spec/services/user_prompt_service_spec.rb
+++ b/spec/services/user_prompt_service_spec.rb
@@ -1,47 +1,30 @@
-require 'spec_helper'
-
-describe UserPromptService do
+RSpec.describe UserPromptService do
   subject(:service) { described_class.new(input_stream) }
 
   let(:input_stream) { StringIO.new(input_sequence) }
 
-  describe '#user_input' do
+  describe '#city_prompt' do
     context 'when the input is help then a valid input' do
       let(:input_sequence) { "help\nBerlin\n" }
 
-      before do
-        berlin_tz = ActiveSupport::TimeZone.find_tzinfo('Berlin')
-        allow(ActiveSupport::TimeZone).to receive(:find_tzinfo).with('Berlin').and_return(berlin_tz)
-        allow(ActiveSupport::TimeZone).to receive(:find_tzinfo).with('Help').and_return(nil)
-      end
-
-      it 'calls the cities_tz_list method and then waits for a new input' do
-        expect(service).to receive(:cities_tz_list)
-        service.user_input
-        expect(service.instance_variable_get('@city_tz').name).to eq('Europe/Berlin')
+      it 'returns the correct timezone' do
+        expect(service.city_prompt.name).to eq('Europe/Berlin')
       end
     end
 
     context 'when input is a valid city' do
-      let(:input_sequence) { "invalid\ninvalid\nNew York\ninvalid\nBerlin\nexit\n" }
+      let(:input_sequence) { "New York\nexit\n" }  # add an exit command
 
-      before do
-        ny_tz = ActiveSupport::TimeZone.find_tzinfo('America/New_York')
-        allow(ActiveSupport::TimeZone).to receive(:find_tzinfo).with('New York').and_return(ny_tz)
-        allow(ActiveSupport::TimeZone).to receive(:find_tzinfo).and_return(nil)
-      end
       it 'sets the timezone correctly' do
-        service.user_input
-        expect(service.instance_variable_get('@city_tz').name).to eq('America/New_York')
+        expect(service.city_prompt.name).to eq('America/New_York')
       end
     end
 
     context 'when input is an invalid city' do
-      let(:input_sequence) { "invalid\nBerlin\n" }
+      let(:input_sequence) { "invalid\nBerlin\nexit\n" }  # add an exit command
 
       it 'sets the timezone to default' do
-        service.user_input
-        expect(service.instance_variable_get('@city_tz').name).to eq('Europe/Berlin')
+        expect(service.city_prompt.name).to eq('Europe/Berlin')
       end
     end
 
@@ -49,20 +32,15 @@ describe UserPromptService do
       let(:input_sequence) { '   ' }
 
       it 'sets the timezone to default' do
-        service.user_input
-        expect(service.instance_variable_get('@city_tz').name).to eq('Europe/Berlin')
+        expect(service.city_prompt.name).to eq('Europe/Berlin')
       end
     end
 
     context 'when input is exit' do
       let(:input_sequence) { "exit\n" }
 
-      before do
-        allow(service).to receive(:exit)
-      end
-
       it 'exits program on "exit" input' do
-        expect { service.user_input }.to raise_error(SystemExit)
+        expect { service.city_prompt }.to raise_error(SystemExit)
       end
     end
   end


### PR DESCRIPTION
Service now correctly parses and prints game information based on the title, including handling missing titles. It shifted from a simple placeholder message to a more comprehensive display, including date, time, teams and tv channel. This also introduces more comprehensive testing, testing different scenarios of title formats.